### PR TITLE
Added feature to look for developer tag of toolchain image

### DIFF
--- a/tools/testenv
+++ b/tools/testenv
@@ -18,6 +18,10 @@ then
 	PORTMAP=""
 fi
 
+DOCKER_IMAGE_DEVELOPER_TAG=$(echo $DOCKER_IMAGE | sed 's/:/:developer-/g')
+if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $DOCKER_IMAGE_DEVELOPER_TAG > /dev/null; then
+	DOCKER_IMAGE=$DOCKER_IMAGE_DEVELOPER_TAG
+fi
 docker run --rm $PORTMAP -e issuetoken -e sonarkey -e DISPLAY -e PULL_REQUEST=false -e DEVUID=${DEV_UID} -e DEVGID=${DEV_GID} -e ORG_NAME=local \
     -v $(pwd):/build -v ${DEVHOME}:/home/developer -v /tmp/.X11-unix:/tmp/.X11-unix \
     -w /build $INTERACTIVE -t ${DOCKER_IMAGE} "$@"


### PR DESCRIPTION
If it finds a developer tag of the same version defined in shippable, then it uses it instead of full version of toolchain.
For instance:
If shippable has defined `kodekonveyor/toolchain:0.1.4alpha7`, it will try to look for `kodekonveyor/toolchain:developer-0.1.4alpha7` on Docker Hub.